### PR TITLE
Implement SSE notifications

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,13 +13,15 @@ import { Label } from '@/components/ui/label';
 import { SaldoIcon, FindMatchIcon } from '@/components/icons/ClashRoyaleIcons';
 import { useToast } from "@/hooks/use-toast";
 import { Coins, UploadCloud, Swords, Layers, Banknote } from 'lucide-react';
-import { requestTransactionAction } from '@/lib/actions'; 
+import { requestTransactionAction } from '@/lib/actions';
+import useTransactionUpdates from '@/hooks/useTransactionUpdates';
 
 
 const HomePageContent = () => {
-  const { user, refreshUser } = useAuth(); 
+  const { user, refreshUser } = useAuth();
   const router = useRouter();
   const { toast } = useToast();
+  useTransactionUpdates();
   
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
   const [depositAmount, setDepositAmount] = useState('');

--- a/src/hooks/useTransactionUpdates.ts
+++ b/src/hooks/useTransactionUpdates.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
+
+/**
+ * Hook to subscribe to transaction updates via Server-Sent Events (SSE).
+ * Listens for backend notifications and refreshes user data when a
+ * transaction changes status (e.g., deposit approved).
+ */
+export default function useTransactionUpdates() {
+  const { user, refreshUser } = useAuth();
+  const { toast } = useToast();
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!user?.id) return;
+
+    const url = `${BACKEND_URL}/api/transacciones/stream/${user.id}`;
+    const es = new EventSource(url);
+    eventSourceRef.current = es;
+
+    es.onmessage = async (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        toast({
+          title: 'Actualización de Transacción',
+          description: `Tu transacción ${data.id} está ahora ${data.estado}.`,
+        });
+        await refreshUser();
+      } catch (err) {
+        console.error('Error procesando evento SSE', err);
+      }
+    };
+
+    es.onerror = (err) => {
+      console.error('SSE error:', err);
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [user, refreshUser, toast]);
+}


### PR DESCRIPTION
## Summary
- add `useTransactionUpdates` hook with SSE logic
- wire SSE hook into HomePage

## Testing
- `npm run typecheck` *(fails: Property 'tagClash' does not exist on type 'BackendUsuarioDto')*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68567042bdd4832dadb1c8c57f6df4a6