### PR TITLE
Add SSE transaction listener page

### DIFF
--- a/src/app/transacciones/page.tsx
+++ b/src/app/transacciones/page.tsx
@@ -1,32 +1,12 @@
 "use client";
 
-import React, { useState } from 'react';
+import React from 'react';
 import AppLayout from '@/components/AppLayout';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { CartoonButton } from '@/components/ui/CartoonButton';
-import { useToast } from '@/hooks/use-toast';
 import useApprovedTransactionsSse, { ApprovedTransaction } from '@/hooks/useApprovedTransactionsSse';
-import { approveTransactionAction } from '@/lib/actions';
 
 export default function TransactionsPage() {
   const approved = useApprovedTransactionsSse();
-  const { toast } = useToast();
-  const [transactionId, setTransactionId] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const handleApprove = async () => {
-    if (!transactionId) return;
-    setLoading(true);
-    const result = await approveTransactionAction(transactionId);
-    setLoading(false);
-    if (result.success) {
-      toast({ title: 'Transacción aprobada', description: `ID ${transactionId} aprobada` });
-      setTransactionId('');
-    } else {
-      toast({ title: 'Error', description: result.error || 'No se pudo aprobar', variant: 'destructive' });
-    }
-  };
 
   return (
     <AppLayout>
@@ -45,16 +25,6 @@ export default function TransactionsPage() {
               </li>
             ))}
           </ul>
-          <div className="flex gap-2">
-            <Input
-              value={transactionId}
-              onChange={(e) => setTransactionId(e.target.value)}
-              placeholder="ID de transacción"
-            />
-            <CartoonButton onClick={handleApprove} disabled={!transactionId || loading}>
-              {loading ? 'Enviando...' : 'Aprobar'}
-            </CartoonButton>
-          </div>
         </CardContent>
       </Card>
     </AppLayout>

--- a/src/app/transacciones/page.tsx
+++ b/src/app/transacciones/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useState } from 'react';
+import AppLayout from '@/components/AppLayout';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { CartoonButton } from '@/components/ui/CartoonButton';
+import { useToast } from '@/hooks/use-toast';
+import useApprovedTransactionsSse, { ApprovedTransaction } from '@/hooks/useApprovedTransactionsSse';
+import { approveTransactionAction } from '@/lib/actions';
+
+export default function TransactionsPage() {
+  const approved = useApprovedTransactionsSse();
+  const { toast } = useToast();
+  const [transactionId, setTransactionId] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleApprove = async () => {
+    if (!transactionId) return;
+    setLoading(true);
+    const result = await approveTransactionAction(transactionId);
+    setLoading(false);
+    if (result.success) {
+      toast({ title: 'Transacción aprobada', description: `ID ${transactionId} aprobada` });
+      setTransactionId('');
+    } else {
+      toast({ title: 'Error', description: result.error || 'No se pudo aprobar', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <AppLayout>
+      <Card className="space-y-4">
+        <CardHeader>
+          <CardTitle className="text-2xl">Transacciones Aprobadas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-2 mb-6">
+            {approved.length === 0 && (
+              <li className="text-muted-foreground">Aún no hay transacciones aprobadas.</li>
+            )}
+            {approved.map((t: ApprovedTransaction) => (
+              <li key={t.id} className="border p-2 rounded">
+                <span className="font-semibold">{t.id}</span> - {t.tipo} por {new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(t.monto)}
+              </li>
+            ))}
+          </ul>
+          <div className="flex gap-2">
+            <Input
+              value={transactionId}
+              onChange={(e) => setTransactionId(e.target.value)}
+              placeholder="ID de transacción"
+            />
+            <CartoonButton onClick={handleApprove} disabled={!transactionId || loading}>
+              {loading ? 'Enviando...' : 'Aprobar'}
+            </CartoonButton>
+          </div>
+        </CardContent>
+      </Card>
+    </AppLayout>
+  );
+}

--- a/src/hooks/useApprovedTransactionsSse.ts
+++ b/src/hooks/useApprovedTransactionsSse.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+export interface ApprovedTransaction {
+  id: string;
+  usuarioId: string;
+  monto: number;
+  tipo: 'DEPOSITO' | 'RETIRO' | 'PREMIO';
+  estado: 'APROBADA';
+  creadoEn: string;
+}
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
+
+export default function useApprovedTransactionsSse() {
+  const [transactions, setTransactions] = useState<ApprovedTransaction[]>([]);
+
+  useEffect(() => {
+    const es = new EventSource(`${BACKEND_URL}/api/sse/transacciones`);
+
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as ApprovedTransaction;
+        setTransactions(prev => [data, ...prev]);
+      } catch (err) {
+        console.error('Error parsing SSE event', err);
+      }
+    };
+
+    es.onerror = (err) => {
+      console.error('SSE error:', err);
+    };
+
+    return () => {
+      es.close();
+    };
+  }, []);
+
+  return transactions;
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -217,3 +217,21 @@ export async function getUserTransactionsAction(
     return { transactions: null, error: error.message || "Error de red al obtener transacciones." };
   }
 }
+
+export async function approveTransactionAction(
+  transactionId: string,
+): Promise<{ success: boolean; error: string | null }> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/transacciones/${transactionId}/aprobar`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ message: `Error del servidor: ${response.status}` }));
+      return { success: false, error: errorData.message || `Error ${response.status} al aprobar transacción.` };
+    }
+    return { success: true, error: null };
+  } catch (error: any) {
+    console.error('Error en approveTransactionAction:', error);
+    return { success: false, error: error.message || 'Error de red al aprobar transacción.' };
+  }
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -218,20 +218,3 @@ export async function getUserTransactionsAction(
   }
 }
 
-export async function approveTransactionAction(
-  transactionId: string,
-): Promise<{ success: boolean; error: string | null }> {
-  try {
-    const response = await fetch(`${BACKEND_URL}/api/transacciones/${transactionId}/aprobar`, {
-      method: 'POST',
-    });
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({ message: `Error del servidor: ${response.status}` }));
-      return { success: false, error: errorData.message || `Error ${response.status} al aprobar transacción.` };
-    }
-    return { success: true, error: null };
-  } catch (error: any) {
-    console.error('Error en approveTransactionAction:', error);
-    return { success: false, error: error.message || 'Error de red al aprobar transacción.' };
-  }
-}


### PR DESCRIPTION
## Summary
- add `useApprovedTransactionsSse` hook to listen to `/api/sse/transacciones`
- add `approveTransactionAction` API call
- create `/transacciones` page to display realtime approved transactions and approve transactions by ID

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856e73ce2f0832d91dbc88a19f11cfa