### PR TITLE
Add modal flow for matchmaking

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SaldoIcon, FindMatchIcon } from '@/components/icons/ClashRoyaleIcons';
 import { useToast } from "@/hooks/use-toast";
-import { Coins, UploadCloud, Swords, Layers, Banknote } from 'lucide-react';
+import { Coins, UploadCloud, Swords, Layers, Banknote, Loader2 } from 'lucide-react';
 import { requestTransactionAction } from '@/lib/actions';
 import useTransactionUpdates from '@/hooks/useTransactionUpdates';
 
@@ -31,6 +31,9 @@ const HomePageContent = () => {
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
   const [withdrawAmount, setWithdrawAmount] = useState('');
   const [isWithdrawLoading, setIsWithdrawLoading] = useState(false);
+
+  const [isModeModalOpen, setIsModeModalOpen] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");
@@ -171,6 +174,27 @@ const HomePageContent = () => {
     }
   };
 
+  // Matchmaking Modal Logic
+  const handleOpenModeModal = () => {
+    if (user.balance < 6000) {
+      toast({
+        title: "Saldo Insuficiente",
+        description: "Necesitas al menos $6,000 COP para buscar un duelo. Por favor, deposita saldo.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setIsModeModalOpen(true);
+  };
+
+  const handleModeSelect = (mode: 'classic' | 'triple-draft') => {
+    setIsModeModalOpen(false);
+    setIsSearching(true);
+    setTimeout(() => {
+      handleFindMatch(mode);
+    }, 300);
+  };
+
 
   return (
     <div className="space-y-8">
@@ -231,27 +255,62 @@ const HomePageContent = () => {
             <br /> Necesitas tener al menos $6,000 COP de saldo.
           </CardDescription>
         </CardHeader>
-        <CardContent className="p-6 flex flex-col sm:flex-row gap-4 justify-center items-center">
+        <CardContent className="p-6 flex justify-center">
           <CartoonButton
-            onClick={() => handleFindMatch('classic')}
+            onClick={handleOpenModeModal}
             className="w-full sm:w-auto"
             iconLeft={<Swords className="h-6 w-6" />}
             disabled={user.balance < 6000}
           >
-            Batalla Clásica
-          </CartoonButton>
-          <CartoonButton
-            onClick={() => handleFindMatch('triple-draft')}
-            className="w-full sm:w-auto"
-            variant="accent" 
-            iconLeft={<Layers className="h-6 w-6" />}
-            disabled={user.balance < 6000}
-          >
-            Triple Elección
+            Buscar Oponente
           </CartoonButton>
         </CardContent>
       </Card>
 
+      {/* Mode Select Modal */}
+      {isModeModalOpen && (
+        <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-fade-in-up">
+          <Card className="w-full max-w-md shadow-xl border-2 border-accent">
+            <CardHeader>
+              <CardTitle className="text-3xl font-headline text-accent text-center">Selecciona Modo</CardTitle>
+            </CardHeader>
+            <CardContent className="p-6 flex flex-col gap-4">
+              <CartoonButton
+                onClick={() => handleModeSelect('classic')}
+                className="w-full"
+                iconLeft={<Swords className="h-6 w-6" />}
+              >
+                Batalla Clásica
+              </CartoonButton>
+              <CartoonButton
+                onClick={() => handleModeSelect('triple-draft')}
+                className="w-full"
+                variant="accent"
+                iconLeft={<Layers className="h-6 w-6" />}
+              >
+                Triple Elección
+              </CartoonButton>
+            </CardContent>
+            <CardFooter className="flex justify-end p-6 pt-0">
+              <CartoonButton variant="secondary" size="small" onClick={() => setIsModeModalOpen(false)}>Cancelar</CartoonButton>
+            </CardFooter>
+          </Card>
+        </div>
+      )}
+
+      {/* Searching Overlay */}
+      {isSearching && (
+        <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-fade-in-up">
+          <Card className="w-full max-w-sm shadow-xl border-2 border-accent text-center space-y-6 p-6">
+            <CardHeader>
+              <CardTitle className="text-2xl font-headline text-primary">Buscando oponente...</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Loader2 className="h-12 w-12 mx-auto text-accent animate-spin" />
+            </CardContent>
+          </Card>
+        </div>
+      )}
 
       {/* Deposit Modal */}
       {isDepositModalOpen && (


### PR DESCRIPTION
## Summary
- replace two-mode buttons with single 'Buscar Oponente' button
- add modal to choose between classic and triple draft
- show a searching overlay when a mode is selected

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6857461a0fe4832db9df5edbff874de9