### PR TITLE
Implement SSE matchmaking listener

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Coins, UploadCloud, Swords, Layers, Banknote, Loader2 } from 'lucide-react';
 import { requestTransactionAction, matchmakingAction } from '@/lib/actions';
 import useTransactionUpdates from '@/hooks/useTransactionUpdates';
+import useMatchmakingSse from '@/hooks/useMatchmakingSse';
 
 
 const HomePageContent = () => {
@@ -34,6 +35,15 @@ const HomePageContent = () => {
 
   const [isModeModalOpen, setIsModeModalOpen] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+
+  const handleMatchFound = (data: { apuestaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
+    setIsSearching(false);
+    router.push(
+      `/chat/${data.apuestaId}?opponentTag=${encodeURIComponent(data.jugadorOponenteTag)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
+    );
+  };
+
+  useMatchmakingSse(isSearching ? user.id : undefined, handleMatchFound);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");
@@ -67,29 +77,24 @@ const HomePageContent = () => {
 
     const result = await matchmakingAction(user.id, mode);
 
+    if (result.error) {
+      toast({
+        title: "Error de Emparejamiento",
+        description: result.error,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSearching(true);
+
     if (
       result.match &&
       result.match.apuestaId &&
       result.match.jugadorOponenteId &&
       result.match.jugadorOponenteTag
     ) {
-      const opp = result.match;
-      router.push(
-        `/chat/${opp.apuestaId}?opponentTag=${encodeURIComponent(
-          opp.jugadorOponenteTag
-        )}&opponentGoogleId=${encodeURIComponent(
-          opp.jugadorOponenteId
-        )}&opponentAvatar=${encodeURIComponent(
-          opp.jugadorOponenteAvatarUrl || ''
-        )}`
-      );
-    } else {
-      toast({
-        title: "Error de Emparejamiento",
-        description: result.error || "No se pudo encontrar un oponente.",
-        variant: "destructive",
-      });
-      setIsSearching(false);
+      handleMatchFound(result.match);
     }
   };
 
@@ -220,7 +225,6 @@ const HomePageContent = () => {
 
   const handleModeSelect = async (mode: 'classic' | 'triple-draft') => {
     setIsModeModalOpen(false);
-    setIsSearching(true);
     await handleFindMatch(mode);
   };
 

--- a/src/hooks/useMatchmakingSse.ts
+++ b/src/hooks/useMatchmakingSse.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { useToast } from '@/hooks/use-toast';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
+
+interface MatchEventData {
+  apuestaId: string;
+  jugadorOponenteId: string;
+  jugadorOponenteTag: string;
+}
+
+export default function useMatchmakingSse(playerId: string | undefined, onMatch: (data: MatchEventData) => void) {
+  const { toast } = useToast();
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!playerId) return;
+
+    const url = `${BACKEND_URL}/sse/match?jugadorId=${encodeURIComponent(playerId)}`;
+    const es = new EventSource(url);
+    eventSourceRef.current = es;
+
+    es.onmessage = (event) => {
+      try {
+        const data: MatchEventData = JSON.parse(event.data);
+        console.log('Match encontrado:', data);
+        onMatch(data);
+        es.close();
+      } catch (err) {
+        console.error('Error al procesar evento SSE de matchmaking:', err);
+      }
+    };
+
+    es.onerror = (err) => {
+      console.error('Error en la conexión SSE de matchmaking:', err);
+      toast({ title: 'Error de Matchmaking', description: 'La conexión se interrumpió.' });
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [playerId, onMatch, toast]);
+}


### PR DESCRIPTION
## Summary
- add hook to listen to `/sse/match` events
- integrate hook in the home page and trigger when searching for a match

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_68578614c0fc832da87b625b4e322a18