### PR TITLE
Add debugging logs for matchmaking

### DIFF
--- a/src/app/matching/page.tsx
+++ b/src/app/matching/page.tsx
@@ -62,8 +62,10 @@ const MatchingPageContent = () => {
     setBetId(null);
 
     const initBet = async () => {
-      if (!user.id) return; 
+      if (!user.id) return;
+      console.log('Creando apuesta para matchmaking:', { userId: user.id, mode });
       const result = await createBetAction(user.id, 6000, mode); // Use user.id (googleId)
+      console.log('Resultado de createBetAction:', result);
       if (result.bet && result.bet.id) {
         setBetId(result.bet.id); // Store the bet's UUID from backend
         setStatus(`Apuesta ${result.bet.id} creada. Buscando oponente para ${modeDisplay}...`);
@@ -75,7 +77,8 @@ const MatchingPageContent = () => {
         // Simulate finding an opponent
         const searchTimeoutId = setTimeout(() => {
           const randomOpponent = mockOpponents[Math.floor(Math.random() * mockOpponents.length)];
-          setOpponent(randomOpponent); 
+          console.log('Oponente simulado encontrado:', randomOpponent);
+          setOpponent(randomOpponent);
           clearInterval(progressInterval); 
           setProgress(100);
           // TODO: En un sistema real, aquí se podría llamar a un endpoint para unir la apuesta `betId`
@@ -99,13 +102,15 @@ const MatchingPageContent = () => {
 
   // Effect to handle navigation once an opponent is found
   useEffect(() => {
-    if (opponent && user && mode && modeDisplay && router && betId) { 
+    if (opponent && user && mode && modeDisplay && router && betId) {
+        console.log('Oponente listo para iniciar duelo:', opponent);
         setStatus(`¡Oponente Encontrado: ${opponent.clashTag} para ${modeDisplay}!`);
 
         const matchStartTimeoutId = setTimeout(() => {
             setStatus(`¡Duelo iniciando con ${opponent.clashTag} (${modeDisplay})!`);
             // El matchId para el chat ahora es el ID de la apuesta del backend (betId - UUID)
             // Se pasa el googleId del oponente para referencia en el chat si es necesario.
+            console.log('Navegando a chat con betId', betId);
             router.push(`/chat/${betId}?opponentTag=${encodeURIComponent(opponent.clashTag)}&opponentAvatar=${encodeURIComponent(opponent.avatarUrl)}&opponentGoogleId=${encodeURIComponent(opponent.id)}`);
         }, 3000);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,13 +37,14 @@ const HomePageContent = () => {
   const [isSearching, setIsSearching] = useState(false);
 
   const handleMatchFound = (data: { apuestaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
+    console.log('Match encontrado via SSE:', data);
     setIsSearching(false);
     router.push(
       `/chat/${data.apuestaId}?opponentTag=${encodeURIComponent(data.jugadorOponenteTag)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
     );
   };
 
-  useMatchmakingSse(isSearching ? user.id : undefined, handleMatchFound);
+  useMatchmakingSse(isSearching ? user?.id : undefined, handleMatchFound);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");
@@ -75,7 +76,9 @@ const HomePageContent = () => {
       return;
     }
 
+    console.log('Iniciando matchmaking con', { userId: user.id, mode });
     const result = await matchmakingAction(user.id, mode);
+    console.log('Resultado de matchmakingAction:', result);
 
     if (result.error) {
       toast({

--- a/src/hooks/useMatchmakingSse.ts
+++ b/src/hooks/useMatchmakingSse.ts
@@ -17,6 +17,7 @@ export default function useMatchmakingSse(playerId: string | undefined, onMatch:
     if (!playerId) return;
 
     const url = `${BACKEND_URL}/sse/match?jugadorId=${encodeURIComponent(playerId)}`;
+    console.log('Abriendo conexión SSE de matchmaking:', url);
     const es = new EventSource(url);
     eventSourceRef.current = es;
 
@@ -37,6 +38,7 @@ export default function useMatchmakingSse(playerId: string | undefined, onMatch:
     };
 
     return () => {
+      console.log('Cerrando conexión SSE de matchmaking');
       es.close();
     };
   }, [playerId, onMatch, toast]);

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -209,6 +209,7 @@ export async function matchmakingAction(
     usuarioId: userGoogleId,
     modoJuego: gameMode,
   };
+  console.log('Llamando a /api/matchmaking/ejecutar con payload:', payload);
   try {
     const response = await fetch(`${BACKEND_URL}/api/matchmaking/ejecutar`, {
 
@@ -226,6 +227,7 @@ export async function matchmakingAction(
       };
     }
     const match = (await response.json()) as BackendMatchmakingResponseDto;
+    console.log('Respuesta de matchmaking:', match);
     if (!match.apuestaId || !match.jugadorOponenteId || !match.jugadorOponenteTag) {
       return {
         match: null,


### PR DESCRIPTION
## Summary
- log SSE connection events in `useMatchmakingSse`
- log matchmaking API calls in `matchmakingAction`
- log matchmaking progress in home and matching pages
- fix optional user ID when subscribing to SSE

## Testing
- `npm ci`
- `npm run typecheck`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68579228fde0832dbb63659ca37568ec